### PR TITLE
AWS SSM: Take optional AWS region param

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ export interface AuthProps {
   token?: string
   base64Token?: string
   getAwsParameterStoreName?: (subdomain: string) => string
+  awsRegion?: string
 }
 
 export interface ConstructorOpts {
@@ -42,7 +43,8 @@ export const createClient = (args: AuthProps, opts?: ConstructorOpts) => {
     // if a function to fetch email+token from AWS was provided, try that
     else if (args.getAwsParameterStoreName) {
       const parameterName = args.getAwsParameterStoreName(subdomain)
-      const ssm = new SSM()
+      // Use custom AWS region if provided
+      const ssm = args.awsRegion ? new SSM({ region: args.awsRegion }) : new SSM()
       const { Parameter } = await ssm.getParameter({ Name: parameterName }).promise()
       const [token, email] = Parameter?.Value?.split(',') || []
       return btoa(`${email}/token:${token}`)

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ export interface AuthProps {
 
 export interface ConstructorOpts {
   log?: boolean
+  logger?: (message: string) => void
 }
 
 export interface Result<BodyType> {
@@ -63,7 +64,8 @@ export const createClient = (args: AuthProps, opts?: ConstructorOpts) => {
     const method = init ? init.method || 'GET' : 'GET'
 
     if (opts?.log) {
-      console.log(`[${method}] ${url} ${init ? init.body : ''}`)
+      const message = `[${method}] ${url} ${init ? init.body : ''}`
+      opts?.logger ? opts.logger(message) : console.log(message)
     }
 
     const res = await fetch(url, {


### PR DESCRIPTION
# Description
Updates the API client auth params to take an optional `AWS` region - this region will be used (if provided) to fetch secrets from Parameter Store over the one passed in environment variables. 

As per [docs](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/setting-credentials-node.html), these credentials take precedence over environment variables.

UPDATE:
Added an optional logger param so I can pass in a custom logger that logs data in the structure I want. 