### PR TITLE
Add email_cc fields to Zendesk.Ticket interface

### DIFF
--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -63,6 +63,8 @@ namespace Zendesk {
     custom_fields?: { id: number; value: any }[]
     fields?: { id: number; value: any }[]
     ticket_form_id?: number
+    email_cc_ids?: string[]
+    collaborator_ids?: string[]
   }
 
   export interface Metadata {


### PR DESCRIPTION
Updates the Zendesk Ticket interface to include the email_cc_ids and collaborator_ids fields. Needed in order to create a faktory job that updates those fields.

Updating interface per this spec: https://developer.zendesk.com/rest_api/docs/support/tickets