### PR TITLE
Stop logging request body

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,9 @@ export interface AuthProps {
 }
 
 export interface ConstructorOpts {
+  /** If true, will log every request minus the body */
   log?: boolean
+  /** If true, will log every request body */
   logFull?: boolean
   logger?: (message: string) => void
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -100,7 +100,7 @@ export const createClient = (args: AuthProps, opts?: ConstructorOpts) => {
     const method = init ? init.method || 'GET' : 'GET'
 
     if (opts?.log) {
-      const message = `[${method}] ${url} ${init ? init.body : ''}`
+      const message = `[${method}] ${url}`
       opts?.logger ? opts.logger(message) : console.log(message)
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -17,6 +17,7 @@ export interface AuthProps {
 
 export interface ConstructorOpts {
   log?: boolean
+  logFull?: boolean
   logger?: (message: string) => void
 }
 
@@ -100,7 +101,7 @@ export const createClient = (args: AuthProps, opts?: ConstructorOpts) => {
     const method = init ? init.method || 'GET' : 'GET'
 
     if (opts?.log) {
-      const message = `[${method}] ${url}`
+      const message = `[${method}] ${url} ${opts?.logFull && init ? init.body : ''}`
       opts?.logger ? opts.logger(message) : console.log(message)
     }
 


### PR DESCRIPTION
This is causing us to use up all our disk space when clients send bulk mailers via unlayer, as the body of the create_many request contains the entirety of the tickets for said request, including a ton of html. Only logging the method and url will prevent that