### PR TITLE
Emattson/eng 11408/deprecate fast paginate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+SUBDOMAIN=indigovdev
+EMAIL=[your indigov email]
+TOKEN=[your indigovdev api token] # create it here https://indigovdev.zendesk.com/admin/apps-integrations/apis/zendesk-api/settings 
+AWS_REGION=us-east-2

--- a/README.md
+++ b/README.md
@@ -108,6 +108,25 @@ await zendeskAPI.fetchAllIncrementalUsers({
 const { email, token, base64Token } = await api.getCreds()
 ```
 
+## Development
+
+## Setup
+
+Set up .env 
+
+```
+cp .env.example .env
+```
+Edit _.env_ to fill out missing data
+
+### Testing
+These are end to end tests against whatever account is configured in your _.env_. Expect them to fail if .env and the zendesk instance are not correctly configured. 
+
+```
+yarn test
+```
+
+
 ## Publishing
 
 Simply run `npm publish` and follow the prompts. **IMPORTANT** Do not run `yarn publish`, it is not compatible and will not include all files.

--- a/src/fast-paginate.ts
+++ b/src/fast-paginate.ts
@@ -6,6 +6,7 @@ import retry from './retry'
 
 const defaultConcurrency = 5
 
+/** @deprecated Use fetchAll instead */
 export default <BodyType>({
   api,
   concurrency,

--- a/src/zendesk.ts
+++ b/src/zendesk.ts
@@ -148,6 +148,21 @@ namespace Zendesk {
     events?: object[]
   }
 
+  export interface AuditLog {
+    url: string
+    id: number
+    action_label: string
+    actor_id: number
+    source_id: number
+    source_type: string
+    source_label: string
+    action: string
+    change_description: string
+    ip_address?: string
+    created_at?: string
+    actor_name: string
+  }
+
   export interface Comment {
     id?: number
     type?: 'Comment' | 'VoiceComment'
@@ -725,32 +740,80 @@ namespace Zendesk {
       }
     }
 
+    export interface AuditLogs extends _ {
+      audit_logs: Zendesk.AuditLog[]
+    }
+
     export interface Tickets extends _ {
       tickets: Zendesk.Ticket[]
     }
 
-    export interface Users extends _ {
-      users: Zendesk.User[]
+    export interface TicketAudits extends _ {
+      audits: Zendesk.TicketAudit[]
     }
 
-    export interface Organizations extends _ {
-      organizations: Zendesk.Organization[]
+    export interface Tickets extends _ {
+      tickets: Zendesk.Ticket[]
     }
 
-    export interface Macros extends _ {
-      macros: Zendesk.Macro[]
+    export interface TicketFields extends _ {
+      ticket_fields: Zendesk.TicketField[]
     }
 
-    export interface Views extends _ {
-      views: Zendesk.View[]
+    export interface TicketForms extends _ {
+      ticket_forms: Zendesk.TicketForm[]
+    }
+
+    export interface Identities extends _ {
+      identities: Zendesk.Identity[]
+    }
+
+    export interface Targets extends _ {
+      targets: Zendesk.Target[]
     }
 
     export interface Triggers extends _ {
       triggers: Zendesk.Trigger[]
     }
 
+    export interface Organizations extends _ {
+      organizations: Zendesk.Organization[]
+    }
+
     export interface Automations extends _ {
       automations: Zendesk.Automation[]
+    }
+
+    export interface Users extends _ {
+      users: Zendesk.User[]
+    }
+
+    export interface UserFields extends _ {
+      user_fields: Zendesk.UserField[]
+    }
+
+    export interface Macros extends _ {
+      macros: Zendesk.Macro[]
+    }
+
+    export interface Groups extends _ {
+      groups: Zendesk.Group[]
+    }
+
+    export interface GroupMemberships extends _ {
+      group_memberships: Zendesk.GroupMembership[]
+    }
+
+    export interface Views extends _ {
+      views: Zendesk.View[]
+    }
+
+    export interface SideConversations extends _ {
+      side_conversations: Zendesk.SideConversation[]
+    }
+
+    export interface SideConversationEvents extends _ {
+      events: Zendesk.SideConversationEvent[]
     }
   }
 


### PR DESCRIPTION
Ticket: ENG-11408

we don't want to use pagination anymore. library already supplies clean ways to get data using fetchAll methods... We just want use the deprecated marker to help identify any remaining usages of it 